### PR TITLE
Clone All the Repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ To the extent possible under law, the owner has waived all copyright and related
 
 #### Tools
 * [Move to Islandora Kit](https://github.com/MarcusBarnes/mik) (Stable) - Converts source content files and accompanying metadata into ingest packages used by existing Islandora batch ingest modules.
+* [Gist to clone/pull All of Islandora Repos](https://gist.github.com/DonRichards/13ed08b62c4a542eee75470529ab0eff) - Bash/Python Scripts that will either clone or pull updates from all of the Islandora repos (Islandora/Islandora-Labs/CLAW)
 
 #### Guides
 * [Modify Islandora objects on-the-fly using Devel “Execute PHP Code”](http://dltj.org/article/modify-islandora-objects-using-devel-module/)


### PR DESCRIPTION
Not sure if people will find this useful. I use it to archive a few times a year and thought I'd share. It does more than suggested in the description.

From a list of organizations (islandora, islandora_Labs, Islandora-CLAW, islandora-interest-groups) 
* If no Organization directory it will create one (example: islandora-Labs)
* If no repo (example: Islandora_vagrant) it will clone the repo
* if repo exist it does a pull to get the latest updates
* also it does the same a user array. Mine is in there by default but anyone can add a username. 