### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,108 +4,23 @@ If you are reading this document then you are interested in contributing to Isla
 
 We also have an irc channel -- #islandora -- on freenode.net. Feel free to hang out there, ask questions, and help others out if you can.
 
-Please note that this CONTRIBUTING.md file differs from our standard in the [Contribute Code](contribute-code) and [License Agreements](license-agreements) sections because Awesome Islandora is shared on a [CC0 Public Domain license](https://creativecommons.org/publicdomain/zero/1.0/).
-
-## Workflows
-
-Islandora Committers Calls happen every Thursday at 2PM EST. The meetings are generally held on Skype, and you can join the calls by sending a request to community@islandora.ca.
-
-### Documentation
-
-You can contribute documentation in two different ways. One way is to join the [Documentation Interest Group](https://github.com/islandora-interest-groups/Islandora-Documentation-Interest-Group). Another way is to [open an issue](https://jira.duraspace.org/secure/CreateIssue!default.jspa). You will need a JIRA account to do this. If you don't have one, you can sign up [here](https://jira.duraspace.org/secure/Signup!default.jspa). Set the Issue Type to "Documentation".
-
-### Request a new feature (use cases).
-
-To request a new feature you should [open an issue](https://jira.duraspace.org/secure/CreateIssue!default.jspa). You will need a JIRA account to do this. If you don't have one, you can sign up [here](https://jira.duraspace.org/secure/Signup!default.jspa). Set the Issue Type to "New Feature".
-
-In order to help us understand the feature request, it would be great if you could provide us with a use case:
-
-| Title (Goal)  | The title or goal of your use case                            |
---------------- |------------------------------------                           |
-| Primary Actor | Repository architect, implementer, repository admin, user     |
-| Scope         | The scope of the project. Example: architecture, access       |
-| Level         | The priority the use case should be given; High, Medium, Low  |
-| Story         | This is a [user story](http://en.wikipedia.org/wiki/User_story).
+Please note that this CONTRIBUTING.md file differs from our standard in the [Contribute Code](contribute-code) and [License Agreements](license-agreements) sections because Awesome Islandora is shared on a [CC0 Public Domain license](https://creativecommons.org/publicdomain/zero/1.0/) and the contribution process has been simplified.
 
 
-***
+### Contribute to the Awesome Islandora List
 
-**Examples**:
-* Bullet
-* Listed
-* Examples should you want to provide them.
+For most Islandora contributions, you would need to have completed a [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or be covered by a [Corporate Contributor Licencse Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). The Islandora Awesome list is shared on a [CC0 Public Domain license](https://creativecommons.org/publicdomain/zero/1.0/), as are all additions. By contributing to the list, your additions will also be shared under this licence. A CLA is not required for contributions to Islandora Awesome.
 
-**Remarks**:
-* Bullet
-* Listed
-* Remarks should you want to provide them.
+To contribute to the Awesome Islandora please ensure your pull request adheres to the following guidelines:
 
-### Report a bug
-
-To report a bug you should [open an issue](https://jira.duraspace.org/secure/CreateIssue!default.jspa) that summarizes the bug. Set the Issue Type to "Bug".
-
-In order to help us understand and fix the bug it would be great if you could provide us with:
-
-1. The steps to reproduce the bug. This includes information about e.g. the Islandora version you were using along with version of stack components.
-2. The expected behavior.
-3. The actual, incorrect behavior.
-
-Feel free to search the issue queue for existing issues (aka tickets) that already describe the problem; if there is such a ticket please add your information as a comment.
-
-**If you want to provide a pull along with your bug report:**
-
-That is great! In this case please send us a pull request as described in section _Create a pull request_ below.
-
-### Participate in a Release
-
-Islandora releases occur twice yearly, at the end of April and October. Two to three months before a release, a Call for Volunteers will be issued across Islandora communication channels (website, Twitter, listservs). The Release team consists of both developers and end-users who fix bugs, test fixes, verify improvements and new features; update documentation; and review README and LICENSE files. A Release VM is issued with each release so that testers can have a stable, easy-to-deploy environment in which to work.
-
-To join an Islandora Release Team, sign up for one or more modules in any of the following roles:
-
-* **Component Manager** (Very familiar with module code; reviews commits)
-* **Tester** (Tests JIRA tickets marked "Ready for test" and does a general workover of the module)
-* **Documentor** (Reviews and updates existing documentation or writes new documentation for new modules)
-* **Auditor** (Reviews and updates README and LICENSE files to ensure complaince with templates and standards)
-
-### Contribute code
-
-For most Islandora contributions, you would need to have completed a [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or be covered by a [Corporate Contributor Licencse Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Awesome Islandora is shared on a [CC0 Public Domain license](https://creativecommons.org/publicdomain/zero/1.0/), as are all additions. By contributing to the list, your additions will also be shared under this licence. A CLA is not required for contributions to Awesome Islandora.
-
-To contribute to Awesome Islandora please ensure your pull request adheres to the following guidelines:
-
-Use the following format:
-[Module Name](link) (Status: Stable or In Development) - Brief Description of what the module does
-Make an individual pull request for each new item.
-Link additions should be inserted alphabetically to the relavant category
-New categories or improvements to the existing categorization are welcome.
-Check your spelling and grammar.
-The pull request and commit should have a useful title.
-
-_If you are interested in contributing code to Islandora but do not know where to begin:_
-
-In this case you should [browse open issues](https://jira.duraspace.org/issues/?jql=project%20%3D%20ISLANDORA%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC).
-
-If you are contributing Drupal code, it must adhere to [Drupal Coding Standards](https://www.drupal.org/coding-standards); Travis CI will check for this on pull requests. You should also follow the Islandora community's [Git Guidelines and Best Practices](https://github.com/Islandora/islandora/wiki/Git-Guidelines-and-Best-Practices). 
-
-Contributions to the Islandora codebase should be sent as GitHub pull requests. See section _Create a pull request_ below for details. If there is any problem with the pull request we can work through it using the commenting features of GitHub.
-
-* For _small patches_, feel free to submit pull requests directly for those patches.
-* For _larger code contributions_, please use the following process. The idea behind this process is to prevent any wasted work and catch design issues early on.
-
-    1. [Open an issue](https://jira.duraspace.org/secure/CreateIssue!default.jspa) and assign it the label of "New Feature" or "Improvement", if a similar issue does not exist already. If a similar issue does exist, then you may consider participating in the work on the existing issue.
-    2. Comment on the issue with your plan for implementing the issue. Explain what pieces of the codebase you are going to touch and how everything is going to fit together.
-    3. Islandora committers will work with you on the design to make sure you are on the right track.
-    4. Implement your issue, create a pull request (see below), and iterate from there.
-
-Developer questions? We have a lot of excellent developer documentation that can be found [here](https://github.com/islandora/islandora/wiki#documentation-for-developers).
-
-#### Issue / Topic Branches
-
-All JIRA issues should be worked on in separate git branches. The branch name should be the same as the JIRA issue number, including all-caps, so ISLANDORA-153, ISLANDORA-118, etc.
-
-Example: `git checkout -b 7.x-ISLANDORA-977` or `git checkout -b 7.x-1.4-ISLANDORA-977`
-
-
+* Use the following format:* Use the following format:
+   * `[Module Name](link)` (Status: **Stable** or **In Development**) - Brief Description of what the module does
+* Make an individual pull request for each new item.
+* Link additions should be inserted alphabetically to the relavant category
+* New categories or improvements to the existing categorization are welcome.
+* Check your spelling and grammar.
+* The pull request and commit should have a useful title.
+   
 ### Create a pull request
 
 Take a look at [Creating a pull request](https://help.github.com/articles/creating-a-pull-request). In a nutshell you
@@ -117,24 +32,18 @@ need to:
 
 You may want to read [Syncing a fork](https://help.github.com/articles/syncing-a-fork) for instructions on how to keep your fork up to date with the latest changes of the upstream (official) `islandora` repository.
 
-Community members who have push/merge permissions on a repository should **never** push directly to a repo, nor merge their own pull requests. 
+Community members who have push/merge permissions on a repository should **never** push directly to a repo. 
 
-#### Release branch pull requests
+### Merging Pull Requests
 
-The pull request process will roughly look like this:
+In Islandora Labs, the policies for merging may be different from the standard Islandora [Committer's Workflow](https://github.com/Islandora/islandora/wiki/Islandora-Committers-Workflow). These policies are set at the discretion of the Current Maintainer, as defined in this project's README.md.
 
-1. fork from Islandora repo if that has not already been done
-2. `git remote add islandora git@github.com:Islandora/islandora_checksum.git`
-3. `git pull islandora 7.x`
-4. Make changes, commit
-5. `git push origin 7.x` and issue a pull request on 7.x
-6. `git fetch --all`
-7. `git checkout 7.x-1.4` if that does not work, `git checkout islandora/7.x-1.4` then `git checkout -b 7.x-1.4`
-8. Make changes/cherry pick/copy changes from earlier, commit
-9. `git push origin 7.x-1.4` and issue a pull request on 7.x-1.4
+In this project, the following policies apply:
+
+* The maintainer(s) of this module, and any Islandora Committers, have merge privileges.
+* Merging one's own pull requests is permitted for Islandora Committers.
+* Formal github review is not required, nor is a courtesy waiting period required. Entries should be reviewed for compliance with the [Islandora Community Code of Coduct](https://islandora.ca/codeofconduct).
 
 ## License Agreements
-
-The Islandora Foundation normally requires that contributors complete a [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or be covered by a [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). The signed copy of the license agreement should be sent to <a href="mailto:community@islandora.ca?Subject=Contributor%20License%20Agreement" target="_top">community@islandora.ca</a>. This license is for your protection as a contributor as well as the protection of the Foundation and its users; it does not change your rights to use your own contributions for any other purpose. A list of current CLAs is kept [here](https://github.com/Islandora/islandora/wiki/Contributor-License-Agreements).
 
 Awesome Islandora is shared on a [CC0 Public Domain license](https://creativecommons.org/publicdomain/zero/1.0/), as are all additions. By contributing to the list, your additions will also be shared under this licence. A CLA is not required for contributions to Awesome Islandora.


### PR DESCRIPTION
Cleaning up text that doesn't apply so it's more clear and easier to follow. The old CONTRIBUTING.md was based heavily on the standard one, and contains a ton of stuff that really doesn't apply. To encourage more contributions and make the process easier to follow, I have based it more closely on the simplified [Islandora Bibliography](https://github.com/Islandora-Labs/islandora_bibliography/blob/master/CONTRIBUTING.md) CONTRIBUTING.md instead.